### PR TITLE
chore(ovos-skill-spotify): allow ovos-workshop<9.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 ovos-utils>=0.5.0
 ovos-bus-client>=0.0.9,<2.0.0
-ovos-workshop>=0.0.16,<8.0.0
+ovos-workshop>=0.0.16,<9.0.0
 spotipy


### PR DESCRIPTION
Update ovos-workshop dependency upper bound to <9.0.0